### PR TITLE
Only allows buttons to trigger weather fetching event in hitoryList

### DIFF
--- a/Develop/Assets/script.js
+++ b/Develop/Assets/script.js
@@ -100,6 +100,12 @@ onLoad();
 
 
 historyList.addEventListener('click', function (event) {
+    //Makes sure the event only occurs when the user clicks on a button in the historyList area
+    var isButton = event.target.nodeName === 'BUTTON';
+    if (!isButton) {
+        return;
+    }
+    //Weather fetching
     console.log(event.target.textContent);
     var city = event.target.textContent;
     var currentWeather = "https://api.openweathermap.org/data/2.5/weather?q=" + city + "&appid=942ef25f0bc73d998fa814566b74ba7e&units=imperial"


### PR DESCRIPTION
This update prevents the user from triggering an undefined weather fetch when clicking around the historyList area, making only the buttons trigger the weather fetching functions.